### PR TITLE
feat: Add Red Hat favicon to demo page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hybrid Cloud Console Image Library</title>
+    <link rel="icon" type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico">
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html> 

--- a/webpack.demo.config.js
+++ b/webpack.demo.config.js
@@ -102,7 +102,12 @@ const config = {
       },
     ],
   },
-  plugins: [new HtmlWebpackPlugin(), componentImportsPlugin],
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './src/index.html'
+    }),
+    componentImportsPlugin
+  ],
   devServer: {
     port: 8003,
   },


### PR DESCRIPTION
- Create custom HTML template with Red Hat favicon link
- Update webpack config to use custom template
- Add favicon from access.redhat.com for branding consistency
- Improve page title for better user experience